### PR TITLE
Replace g28 with g0

### DIFF
--- a/SD card files for hotend probe/sys/bed.g
+++ b/SD card files for hotend probe/sys/bed.g
@@ -11,4 +11,4 @@ G30 P7 X54.13 Y-31.25 Z-99999
 G30 P8 X-54.13 Y-31.25 Z-99999
 G30 P9 X0 Y0 Z-99999 S6
 
-G28
+G0 Z150    ; Move the extruder out of the way

--- a/SD/sys/bed.g
+++ b/SD/sys/bed.g
@@ -11,4 +11,4 @@ G30 P7 X54.13 Y-31.25 Z-99999
 G30 P8 X-54.13 Y-31.25 Z-99999
 G30 P9 X0 Y0 Z-99999 S6
 
-G28
+G0 Z150    ; Move the extruder out of the way


### PR DESCRIPTION
I removed the second g28 from bed.g and replaced with a g0 move so it won't home after completing delta calibration.  This has been recommended by Michael Hackney to remove any issues due to homing.